### PR TITLE
BAU: Add uri format mapping to JSON schema

### DIFF
--- a/linkml/generators/jsonschemagen.py
+++ b/linkml/generators/jsonschemagen.py
@@ -26,6 +26,7 @@ json_schema_types: Dict[str, Tuple[str, Optional[str]]] = {
     "xsddate": ("string", "date"),
     "xsddatetime": ("string", "date-time"),
     "xsdtime": ("string", "time"),
+    "uri": ("string", "uri"),
 }
 
 WITH_OPTIONAL_IDENTIFIER_SUFFIX = '__identifier_optional'


### PR DESCRIPTION
## What

- Add JSON schema type mapping from LinkML `uri` to JSON schema `string` with uri `format` set.

## Why

Without this a URI slot get rendered in JSON schema as a simple `string` which is too permissive, we should apply JSON Schema's `uri` format to the field.